### PR TITLE
Upgrade the dependencies to latest.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ name = "uniffi_bindgen"
 path = "src/bin/uniffi_bindgen.rs"
 
 [dependencies]
-c2pa = {version="0.28.3" , features = [ "add_thumbnails", "openssl_sign"]}
+c2pa = {version="0.32.1" , features = [ "add_thumbnails", "openssl_sign"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-serde_with = "2.0.1"
+serde_with = "3.8.1"
 thiserror = "1.0"
-uniffi = "0.24.3"
+uniffi = "0.27.2"
 openssl = { version = "0.10.48", features = ["vendored"] }
-openssl-sys = { version = "=0.9.92"}
+openssl-sys = { version = "0.9.102"}
 pem = "3.0.2"
 
 [build-dependencies]
-uniffi = { version = "0.24.3", features = [ "build", "cli"] }
+uniffi = { version = "0.27.2", features = [ "build", "cli"] }
 
 #[profile.release] 
 #strip = true  # Automatically strip symbols from the binary. 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ endif
 
 # default version of python is 3.11
 PYTHON=python3.11
+LIBRARY=libc2pa_bindings.dylib
 
 release: 
 	cargo build --release --features=uniffi/cli
@@ -16,15 +17,15 @@ release:
 test_c: release
 	cbindgen --config cbindgen.toml --crate c2pa-bindings --output tests/c/c2pa.h --lang c
 	$(CC) $(CFLAGS) tests/c/main.c -o target/ctest -lc2pa_bindings -L./target/release 
-	target/ctest
+	LD_LIBRARY_PATH=target/release target/ctest
 
 python: release
 	cargo run --release --features=uniffi/cli --bin uniffi_bindgen generate src/c2pa.udl -n --language python -o target/python
-	cp target/release/libc2pa_bindings.dylib target/python/libuniffi_c2pa.dylib
+	cp target/release/$(LIBRARY) target/python/
 
 swift: release
 	cargo run --release --features=uniffi/cli --bin uniffi_bindgen generate src/c2pa.udl -n --language swift -o target/swift
-	cp target/release/libc2pa_bindings.dylib target/swift/libuniffi_c2pa.dylib
+	cp target/release/$(LIBRARY) target/swift/
 
 test_python: python
 	$(PYTHON) tests/python/test.py

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -88,7 +88,7 @@ impl AsMut<dyn Stream> for dyn Stream {
 }
 
 pub struct StreamAdapter<'a> {
-    pub stream: &'a mut dyn Stream,
+    pub stream: &'a dyn Stream,
 }
 
 impl<'a> StreamAdapter<'a> {
@@ -100,14 +100,10 @@ impl<'a> StreamAdapter<'a> {
 impl<'a> From<&'a dyn Stream> for StreamAdapter<'a> {
     fn from(stream: &'a dyn Stream) -> Self {
         let stream = &*stream as *const dyn Stream as *mut dyn Stream;
-        let stream = unsafe { &mut *stream };
+        let stream = unsafe { & *stream };
         Self { stream }
     }
 }
-
-impl<'a> c2pa::CAIRead for StreamAdapter<'a> {}
-
-impl<'a> c2pa::CAIReadWrite for StreamAdapter<'a> {}
 
 impl<'a> Read for StreamAdapter<'a> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {

--- a/tests/python/c2pa_api.py
+++ b/tests/python/c2pa_api.py
@@ -124,8 +124,8 @@ class LocalSigner:
     def signer(self):
         return self.signer
     
-    def from_settings(sign_callback, alg, certs, timestamp_url=None):
-        config = c2pa.SignerConfig(alg, certs, timestamp_url)
+    def from_settings(sign_callback, alg, certs, timestamp_url=None, use_ocsp = False):
+        config = c2pa.SignerConfig(alg = alg, certs = certs, time_authority_url = timestamp_url, use_ocsp = use_ocsp)
         return LocalSigner(config, sign_callback).signer
 
 class ManifestBuilder(c2pa.ManifestBuilder):

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -103,7 +103,7 @@ signer = c2pa_api.LocalSigner.from_settings(sign_ps256, "ps256", certs, "http://
 
 # Example of signing a manifest store into a file
 try:
-    settings = c2pa_api.c2pa.ManifestBuilderSettings("python-generator") 
+    settings = c2pa_api.c2pa.ManifestBuilderSettings(generator = "python-generator") 
     c2pa_api.ManifestBuilder.sign_with_files(settings, signer, manifestDefinition, testFile, outFile)
     #builder = c2pa_api.ManifestBuilder(settings, signer, manifestDefinition)
     #c2pa_api.ManifestBuilder.sign(testFile, outFile) 


### PR DESCRIPTION
Fix the python tests as python bindings use kwargs. Fix compliation on the latest rust compiler.